### PR TITLE
[1.1.8] Filter out endpoints for other gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ security/cmd/node_agent/na/cert_file
 security/cmd/node_agent/na/pkey
 # Test artifacts
 tests/e2e/local/minikube/docker-machine-driver-hyperkit
+
+out/
+var/

--- a/getyourguide/README.md
+++ b/getyourguide/README.md
@@ -22,8 +22,7 @@
     -   All proxies without `REQUESTED_NETWORK_VIEW` set will see all networks. Proxies with `REQUESTED_NETWORK_VIEW` configured will only see the local network plus the ones explicitly defined.
 
 ```shell
-docker build -t sre/istio-sidecar-injector -f getyourguide/pilot.dockerfile .
-docker tag sre/istio-pilot:latest 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched
+docker build -t 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched -f getyourguide/pilot.dockerfile .
 docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched
 ```
 

--- a/getyourguide/README.md
+++ b/getyourguide/README.md
@@ -2,10 +2,27 @@
 
 ## Pilot
 
-Disables support for workload label updates, based on [upstream patch](https://github.com/istio/istio/pull/16748).
+1.  Disables support for workload label updates, based on [upstream patch](https://github.com/istio/istio/pull/16748).
+2.  Filters out STATIC service entry endpoints from Ingress Gateways, based on [upstream patch](https://github.com/istio/istio/pull/26729/files). Context for the problem can be found in [this doc](https://docs.google.com/document/d/19Bp-rL4GSZfuwKZKJSt9VPPOAwfnW1MrWyO_mvmBjXE/edit#heading=h.jepy8uc455ut).
 
-```
-docker build -t sre/istio-pilot -f getyourguide/pilot.dockerfile .
+    -   `REQUESTED_NETWORK_VIEW` needs to be set in the Ingress Gateway to `networkA`.
+    -   `network` needs to be set to the ServiceEntry (with resolution type `STATIC`) to `networkB`.
+    -   [meshNetworks](https://github.com/getyourguide/k8s-platform/blob/master/charts/istio/values.jinja2.yaml#L629) needs to be set.
+
+    ```yaml
+    meshNetworks:
+      networkB:
+        endpoints:
+        - fromCidr: "10.20.0.0/20"
+        gateways:
+        - address: 10.20.7.196
+            port: 8001
+    ```
+
+    -   All proxies without `REQUESTED_NETWORK_VIEW` set will see all networks. Proxies with `REQUESTED_NETWORK_VIEW` configured will only see the local network plus the ones explicitly defined.
+
+```shell
+docker build -t cainelli/pilot:1.1.8-patched -f getyourguide/pilot.dockerfile .
 docker tag sre/istio-pilot:latest 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched
 docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched
 ```
@@ -14,7 +31,7 @@ docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.
 
 Puts `istio-proxy` at first position in list of containers, based on [upstream patch](https://github.com/istio/istio/pull/24737).
 
-```
+```shell
 docker build -t sre/istio-sidecar-injector -f getyourguide/sidecar-injector.dockerfile .
 docker tag sre/istio-sidecar-injector:latest 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-sidecar-injector:1.1.8-patched
 docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-sidecar-injector:1.1.8-patched
@@ -24,7 +41,7 @@ docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-sidecar-in
 
 Adds the `wait` command to `pilot-agent`, based on [upstream patch](https://github.com/istio/istio/pull/24737).
 
-```
+```shell
 docker build -t sre/istio-proxyv2 -f getyourguide/proxyv2.dockerfile .
 docker tag sre/istio-proxyv2:latest 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-proxyv2:1.1.8-patched
 docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-proxyv2:1.1.8-patched

--- a/getyourguide/README.md
+++ b/getyourguide/README.md
@@ -3,7 +3,7 @@
 ## Pilot
 
 1.  Disables support for workload label updates, based on [upstream patch](https://github.com/istio/istio/pull/16748).
-2.  Filters out STATIC service entry endpoints from Ingress Gateways, based on [upstream patch](https://github.com/istio/istio/pull/26729/files). Context for the problem can be found in [this doc](https://docs.google.com/document/d/19Bp-rL4GSZfuwKZKJSt9VPPOAwfnW1MrWyO_mvmBjXE/edit#heading=h.jepy8uc455ut).
+2.  Filters out STATIC service entry endpoints with `network` field from Ingress Gateways, based on [upstream patch](https://github.com/istio/istio/pull/26729/files). Context for the problem can be found in [this doc](https://docs.google.com/document/d/19Bp-rL4GSZfuwKZKJSt9VPPOAwfnW1MrWyO_mvmBjXE/edit#heading=h.jepy8uc455ut).
 
     -   `REQUESTED_NETWORK_VIEW` needs to be set in the Ingress Gateway to `networkA`.
     -   `network` needs to be set to the ServiceEntry (with resolution type `STATIC`) to `networkB`.

--- a/getyourguide/README.md
+++ b/getyourguide/README.md
@@ -22,7 +22,7 @@
     -   All proxies without `REQUESTED_NETWORK_VIEW` set will see all networks. Proxies with `REQUESTED_NETWORK_VIEW` configured will only see the local network plus the ones explicitly defined.
 
 ```shell
-docker build -t cainelli/pilot:1.1.8-patched -f getyourguide/pilot.dockerfile .
+docker build -t sre/istio-sidecar-injector -f getyourguide/pilot.dockerfile .
 docker tag sre/istio-pilot:latest 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched
 docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.1.8-patched
 ```

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -78,8 +78,8 @@ func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 				lbEndpoints = append(lbEndpoints, lbEp)
 			} else {
 				// Only send endpoints from the networks in the network view requested by the proxy.
-				// The default network view assigned to the Proxy is nil, in that case match any network.
-				if networkView != nil && !networkView[epNetwork] {
+				// The default network view assigned to the Proxy is "" (UnnamedNetwork), in that case match any network if only contains it in the list.
+				if len(networkView) > 1 && !networkView[epNetwork] {
 					// Endpoint's network doesn't match the set of networks that the proxy wants to see.
 					continue
 				}

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -79,7 +79,7 @@ func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 			} else {
 				// Only send endpoints from the networks in the network view requested by the proxy.
 				// The default network view assigned to the Proxy is "" (UnnamedNetwork), in that case match any network if only contains it in the list.
-				if len(networkView) > 1 && !networkView[epNetwork] {
+				if !networkView[model.UnnamedNetwork] && !networkView[epNetwork] {
 					// Endpoint's network doesn't match the set of networks that the proxy wants to see.
 					continue
 				}

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -39,6 +39,8 @@ func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 		network = ""
 	}
 
+	networkView := model.GetNetworkView(conn.modelNode)
+
 	// calculate the multiples of weight.
 	// It is needed to normalize the LB Weight across different networks.
 	multiples := 1
@@ -75,6 +77,12 @@ func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 				}
 				lbEndpoints = append(lbEndpoints, lbEp)
 			} else {
+				// Only send endpoints from the networks in the network view requested by the proxy.
+				// The default network view assigned to the Proxy is nil, in that case match any network.
+				if networkView != nil && !networkView[epNetwork] {
+					// Endpoint's network doesn't match the set of networks that the proxy wants to see.
+					continue
+				}
 				// Remote endpoint. Increase the weight counter
 				remoteEps[epNetwork]++
 			}


### PR DESCRIPTION
Based on https://github.com/istio/istio/pull/26729

We need [meshNetworks](https://github.com/getyourguide/k8s-platform/blob/master/charts/istio/values.jinja2.yaml#L629)  to get it working.

```yaml
  meshNetworks:
    sandbox11:
      endpoints:
      - fromCidr: "10.20.0.0/20"
      gateways:
      - address: 10.20.7.196
        port: 8001
```