### PR TITLE
[1.7.4] Disable strict mTLS ep for multicluster

### DIFF
--- a/getyourguide/README.md
+++ b/getyourguide/README.md
@@ -1,0 +1,11 @@
+# Build patched images
+
+## Pilot
+
+1.  Disabled strict mTLS cross network endpoints (<https://github.com/istio/istio/pull/26486>)
+    -   This is temporary during the clusters migration period.
+
+```shell
+$ sudo make docker.pilot
+$ docker push 130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre/istio-pilot:1.7.4-patched
+```

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -21,7 +21,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
@@ -70,10 +69,6 @@ func EndpointsByNetworkFilter(b EndpointBuilder, endpoints []*endpoint.LocalityL
 				if !b.canViewNetwork(epNetwork) {
 					continue
 				}
-				if tlsMode := envoytransportSocketMetadata(lbEp, "tlsMode"); tlsMode == model.DisabledTLSModeLabel {
-					// dont allow cross-network endpoints for uninjected traffic
-					continue
-				}
 
 				// Remote network endpoint which can not be accessed directly from local network.
 				// Increase the weight counter
@@ -112,8 +107,6 @@ func EndpointsByNetworkFilter(b EndpointBuilder, endpoints []*endpoint.LocalityL
 						Value: weight,
 					},
 				}
-				// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
-				gwEp.Metadata = util.BuildLbEndpointMetadata("", network, model.IstioMutualTLSModeLabel, b.push)
 				lbEndpoints = append(lbEndpoints, gwEp)
 			}
 		}

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -268,6 +268,8 @@ docker.distroless: docker/Dockerfile.distroless
 DOCKER_BUILD_VARIANTS ?= default
 DOCKER_ALL_VARIANTS ?= default distroless
 DEFAULT_DISTRIBUTION=default
+HUB=130607246975.dkr.ecr.eu-central-1.amazonaws.com/sre
+TAG=1.7.4-patched
 DOCKER_RULE ?= $(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time (mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp -r $^ $(DOCKER_BUILD_TOP)/$@ && cd $(DOCKER_BUILD_TOP)/$@ $(BUILD_PRE) && docker build $(BUILD_ARGS) --build-arg BASE_DISTRIBUTION=$(VARIANT) -t $(HUB)/$(subst docker.,,$@):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) -f Dockerfile$(suffix $@) . ); )
 RENAME_TEMPLATE ?= mkdir -p $(DOCKER_BUILD_TOP)/$@ && cp $(ECHO_DOCKER)/$(VM_OS_DOCKERFILE_TEMPLATE) $(DOCKER_BUILD_TOP)/$@/Dockerfile$(suffix $@)
 


### PR DESCRIPTION
Non-mTLS LB endpoints [are filtered out](https://github.com/istio/istio/pull/26486/files) from the endpoint list. As we need to reach non mTLS enabled clusters during the migration we temporarily disable this filter.

