### PR TITLE
sudo security patch

### DIFF
--- a/getyourguide/pilot.dockerfile
+++ b/getyourguide/pilot.dockerfile
@@ -11,4 +11,6 @@ RUN PROXY_REPO_SHA=4157a97bd82940cff8f775c42ac00c5219d5609b bash -c "make pilot-
 
 FROM istio/pilot:1.1.8
 
+RUN sudo apt update; sudo apt --only-upgrade install sudo
+
 COPY --from=builder /go/out/linux_amd64/release/pilot-discovery /usr/local/bin/pilot-discovery

--- a/getyourguide/proxyv2.dockerfile
+++ b/getyourguide/proxyv2.dockerfile
@@ -11,4 +11,6 @@ RUN PROXY_REPO_SHA=4157a97bd82940cff8f775c42ac00c5219d5609b bash -c "make pilot-
 
 FROM istio/proxyv2:1.1.8
 
+RUN sudo apt update; sudo apt --only-upgrade install sudo
+
 COPY --from=builder /go/out/linux_amd64/release/pilot-agent /usr/local/bin/pilot-agent


### PR DESCRIPTION
[new images are already pushed]

upgrade sudo, luckily the path was backported.

check for backport:
`sudo apt update; apt changelog sudo | grep CVE-2021-3156`

Verified by running `sudoedit -s /`
It will take some time for all sidecar proxies to roll out/replace all pods